### PR TITLE
Fix ietf yang search path for cvl schema builds

### DIFF
--- a/cvl/schema/Makefile
+++ b/cvl/schema/Makefile
@@ -34,7 +34,7 @@ out_platform=$(patsubst %.yang, $(out_dir)/%.yin, $(shell find $(sonic_yang_plat
 out_platform_dep=$(shell find $(sonic_yang_platform) -name '*.yang')
 out_tree=$(patsubst %.yang, $(out_dir)/%.tree, $(src_files)) 
 
-search_path=$(sonic_yang):$(sonic_yang_common):$(sonic_yang_common)/ietf
+search_path=$(std_yang_common):$(sonic_yang):$(sonic_yang_common)
 
 
 all: precheck schema

--- a/cvl/testdata/schema/Makefile
+++ b/cvl/testdata/schema/Makefile
@@ -19,12 +19,14 @@
 
 TOPDIR?=$(abspath ../../../)
 
+yang_dir=../../../models/yang
 sonic_yang=../../../models/yang/sonic
 pyang_plugin_dir=../../../tools/pyang/pyang_plugins
 src_files=$(wildcard *.yang)
 out_dir=$(TOPDIR)/build/tests/cvl/testdata/schema/
 out=$(patsubst %.yang, $(out_dir)/%.yin, $(src_files)) 
 out_ext=$(patsubst %.yang, $(out_dir)/%.tree, $(src_files)) 
+search_path=$(yang_dir)/common:$(sonic_yang):$(sonic_yang)/common
 
 all:precheck schema
 
@@ -39,14 +41,14 @@ $(out_dir)/%.yin:%.yang
 	@echo "Generating `basename $@` ..."
 	@devFile="`echo $< | cut -d . -f1`-deviation.yang"; \
 	if [ -f $$devFile ] ; then devOpt="--deviation-module $$devFile"; fi; \
-	pyang -p $(sonic_yang)/common:$(sonic_yang)/common/ietf \
+	pyang -p $(search_path) \
 		--plugindir $(pyang_plugin_dir) -f yin-cvl $$devOpt $< -o $@
 
 $(out_dir)/%.tree:%.yang
 	@echo "Generating `basename $@` ..."
 	@devFile="`echo $< | cut -d . -f1`-deviation.yang"; \
 	if [ -f $$devFile ] ; then devOpt="--deviation-module $$devFile"; fi; \
-	pyang -p $(sonic_yang)/common:$(sonic_yang)/common/ietf \
+	pyang -p $(search_path) \
 			-f tree $$devOpt $< -o $@
 
 clean:

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ require (
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/antchfx/jsonquery v1.1.0
 	github.com/antchfx/xmlquery v1.2.1
-	github.com/antchfx/xpath v1.1.2 // indirect
+	github.com/antchfx/xpath v1.1.2
 	github.com/go-redis/redis v6.15.6+incompatible
-	github.com/go-redis/redis/v7 v7.0.0-beta.3.0.20190824101152-d19aba07b476 // indirect
+	github.com/go-redis/redis/v7 v7.0.0-beta.3.0.20190824101152-d19aba07b476
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-redis/redis v6.15.6+incompatible h1:H9evprGPLI8+ci7fxQx6WNZHJSb7be8FqJQRhdQZ5Sg=
 github.com/go-redis/redis v6.15.6+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis/v7 v7.0.0-beta.3.0.20190824101152-d19aba07b476 h1:WNSiFp8Ww4ZP7XUzW56zDYv5roKQ4VfsdHCLoh8oDj4=
 github.com/go-redis/redis/v7 v7.0.0-beta.3.0.20190824101152-d19aba07b476/go.mod h1:xhhSbUMTsleRPur+Vgx9sUHtyN33bdjxY+9/0n9Ig8s=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=


### PR DESCRIPTION
1) Fixed pyang search paths in cvl schema makefiles to include top
models/yang/common directory. Without this pyang may not locate ietf
yangs during cvl schema builds, especially while building outside sonic
slave docker.

2) Updated go.mode and go.sum files to include new dependencies added
during recent cvl enhancemnts