### PR TITLE
add fec to sonic-port.yang

### DIFF
--- a/models/yang/sonic/sonic-port.yang
+++ b/models/yang/sonic/sonic-port.yang
@@ -13,7 +13,12 @@ module sonic-port {
 		"SONiC";
 
 	description
-		"SONIC VLAN";
+		"SONIC PORT";
+
+	revision 2021-03-15 {
+		description
+			"Added fec.";
+	}
 
 	revision 2019-05-15 {
 		description
@@ -87,6 +92,15 @@ module sonic-port {
 					type cmn:admin-status;
 					default "down";
 				}
+
+                                leaf fec {
+                                        type string {
+                                                pattern "(none|rs|fc)" {
+                                                        error-message "Invalid interface FEC mode";
+                                                        error-app-tag fec-mode-invalid;
+                                                }
+                                        }
+                                }
 			}
 		}
 	}


### PR DESCRIPTION

When the target contains `FEC` settings, the RESTCONF PATCH to the interface fails.
This PR fix it.

```
admin@sonic:~$ show run ports | jq .Ethernet53
{
  "admin_status": "up",
  "alias": "hundredGigE1/54",
  "fec": "rs",
  "index": "54",
  "lanes": "33,34,35,36",
  "mtu": "9100",
  "speed": "100000"
}
```

```
$ curl -s -X PATCH -H 'Content-Type:application/yang-data+json' -H 'Accept:application/yang-data+json' --insecure 'https://<sonic ip address>/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet53/subinterfaces/subinterface=0' -d '{"openconfig-interfaces:subinterface": [{"index": 0, "openconfig-if-ip:ipv4": { "addresses": { "address": [{ "ip": "172.30.255.3", "config": { "ip": "172.30.255.3", "prefix-length": 31}}]}}}]}'

{"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"invalid-value"}]}}
```

SOINiC's log says `rest-server libyang[0]: Failed to find "fec" as a sibling to "sonic-port:ifname".`

```
Mar 16 10:03:25.899930 sonic INFO mgmt-framework#/supervisord: rest-server I0316 10:03:25.899497      17 router.go:122] [REST-89] Recevied PatchOpenconfigInterfacesInterfacesInterfaceSubinterfacesSubinterface request from 10.138.25.12:43576
Mar 16 10:03:25.900081 sonic INFO mgmt-framework#/supervisord: rest-server I0316 10:03:25.899576      17 handler.go:47] [REST-89] PATCH /restconf/data/openconfig-interfaces:interfaces/interface=Ethernet53/subinterfaces/subinterface=0; content-len=192
Mar 16 10:03:25.900271 sonic INFO mgmt-framework#/supervisord: rest-server I0316 10:03:25.899639      17 handler.go:134] [REST-89] Content-type=application/yang-data+json; data={"openconfig-interfaces:subinterface": [{"index": 0, "openconfig-if-ip:ipv4": { "addresses": { "address": [{ "ip": "172.30.255.3", "config": { "ip": "172.30.255.3", "prefix-length": 31}}]}}}]}

...<snip>

Mar 16 10:03:25.904263 sonic INFO mgmt-framework#/supervisord: rest-server libyang[0]: Failed to find "fec" as a sibling to "sonic-port:ifname".
Mar 16 10:03:25.904334 sonic INFO mgmt-framework#/supervisord: rest-server E0316 10:03:25.903856      17 util.go:176] Failed to create leaf nodes, data = [0xc004ce0f20 0xc004ce0f40 0xc004ce0f60 0xc004ce0fa0 0xc004ce0fc0 0xc004ce0fe0 0xc004ce1000 0xc004ce1020]
Mar 16 10:03:25.904405 sonic INFO mgmt-framework#/supervisord: rest-server libyang[0]: Leafref "/sonic-port:sonic-port/sonic-port:PORT/sonic-port:PORT_LIST/sonic-port:ifname" of value "Ethernet53" points to a non-existing leaf. (path: /sonic-interface:sonic-interface/INTERFACE/INTERFACE_LIST[portname='Ethernet53']/portname)
Mar 16 10:03:25.904500 sonic INFO mgmt-framework#/supervisord: rest-server W0316 10:03:25.903965      17 db.go:650] doCVL: CVL Failure: 1014
Mar 16 10:03:25.904586 sonic INFO mgmt-framework#/supervisord: rest-server I0316 10:03:25.903985      17 db.go:654] doCVL: 1 1
Mar 16 10:03:25.905051 sonic INFO mgmt-framework#/supervisord: rest-server E0316 10:03:25.904206      17 handler.go:59] [REST-89] Translib error tlerr.TranslibCVLFailure - Translib Redis Error: CVL Failure: 1,014: {INTERFACE_LIST 1,014 Dependent Data is missing ['Ethernet53'] Ethernet53 portname INTERFACE_LIST with keys['Ethernet53' ] has field portname with invalid value Ethernet53  }
Mar 16 10:03:25.905120 sonic INFO mgmt-framework#/supervisord: rest-server I0316 10:03:25.904319      17 handler.go:72] [REST-89] Sending response 500, type=application/yang-data+json, data={"ietf-restconf:errors":{"error":[{"error-type":"application","error-tag":"invalid-value"}]}}
Mar 16 10:03:25.905190 sonic INFO mgmt-framework#/supervisord: rest-server I0316 10:03:25.904348      17 router.go:128] [REST-89] PatchOpenconfigInterfacesInterfacesInterfaceSubinterfacesSubinterface took 4.810186ms
```