### PR TITLE
Adding mmu buffer yang files

### DIFF
--- a/models/yang/sonic/sonic-buffer-pg.yang
+++ b/models/yang/sonic/sonic-buffer-pg.yang
@@ -1,0 +1,66 @@
+module sonic-buffer-pg {
+	namespace "http://github.com/Azure/sonic-buffer-pg";
+	prefix bpg;
+
+	import sonic-extension {
+		prefix sonic-ext;
+	}
+
+	import sonic-port {
+		prefix prt;
+	}
+
+	import sonic-buffer-profile {
+		prefix bpf;
+	}
+
+	organization
+		"SONiC";
+
+	contact
+		"SONiC";
+
+	description
+		"SONIC BUFFER PG";
+
+	revision 2019-05-15 {
+		description
+			"Initial revision.";
+	}
+
+
+	container sonic-buffer-pg {
+
+		container BUFFER_PG {
+
+			list BUFFER_PG_LIST {
+				key "ifname pg_num";
+				sonic-ext:key-pattern "BUFFER_PG|{ifname}|{pg_num}"; //special pattern used for extracting keys from
+				//redis-key and fill populate the yang instance
+				// Total list instance = number(key1) * number(key2) * number(key3)
+
+				leaf ifname {
+					type leafref {
+						path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:ifname";
+					}
+				}
+
+				leaf pg_num {
+					type string {
+						pattern "[0-7]((-)[0-7])?" {
+							error-message "Invalid Buffer PG number";
+							error-app-tag pg-num-invalid;
+						}
+					}
+				}
+
+				leaf profile { //Hash reference key
+					type leafref {
+						path "/bpf:sonic-buffer-profile/bpf:BUFFER_PROFILE/bpf:BUFFER_PROFILE_LIST/bpf:name";
+					}
+				}
+
+			}
+		}
+	}
+}

--- a/models/yang/sonic/sonic-buffer-pool.yang
+++ b/models/yang/sonic/sonic-buffer-pool.yang
@@ -1,0 +1,51 @@
+module sonic-buffer-pool {
+	namespace "http://github.com/Azure/sonic-buffer-pool";
+	prefix bpl;
+
+	organization
+		"SONiC";
+
+	contact
+		"SONiC";
+
+	description
+		"SONIC BUFFER POOL";
+
+	revision 2019-05-15 {
+		description
+			"Initial revision.";
+	}
+
+	container sonic-buffer-pool {
+
+		container BUFFER_POOL {
+
+			list BUFFER_POOL_LIST {
+				key "name";
+
+				leaf name {
+					type string;
+				}
+
+				leaf type {
+					type enumeration {
+						enum ingress;
+						enum egress;
+					}
+				}
+
+				leaf mode {
+					type enumeration {
+						enum static;
+						enum dynamic;
+					}
+				}
+
+				leaf size {
+					type uint64;
+				}
+
+			}
+		}
+	}
+}

--- a/models/yang/sonic/sonic-buffer-profile.yang
+++ b/models/yang/sonic/sonic-buffer-profile.yang
@@ -1,0 +1,67 @@
+module sonic-buffer-profile {
+	namespace "http://github.com/Azure/sonic-buffer-profile";
+	prefix bpf;
+
+	import sonic-buffer-pool {
+		prefix bpl;
+	}
+
+	organization
+		"SONiC";
+
+	contact
+		"SONiC";
+
+	description
+		"SONIC BUFFER PROFILE";
+
+	revision 2019-05-15 {
+		description
+			"Initial revision.";
+	}
+
+
+	container sonic-buffer-profile {
+
+		container BUFFER_PROFILE {
+
+			list BUFFER_PROFILE_LIST {
+				key "name";
+
+				leaf name {
+					type string;
+				}
+
+				leaf static_th {
+					type uint64;
+				}
+
+				leaf dynamic_th {
+					type int64;
+				}
+
+				leaf size {
+					type uint64;
+				}
+
+				leaf pool {
+					type leafref {
+						path "/bpl:sonic-buffer-pool/bpl:BUFFER_POOL/bpl:BUFFER_POOL_LIST/bpl:name";
+					}
+				}
+
+				leaf xon_offset {
+					type uint64;
+				}
+
+				leaf xon {
+					type uint64;
+				}
+
+				leaf xoff {
+					type uint64;
+				}
+			}
+		}
+	}
+}

--- a/models/yang/sonic/sonic-buffer-queue.yang
+++ b/models/yang/sonic/sonic-buffer-queue.yang
@@ -1,0 +1,65 @@
+module sonic-buffer-queue {
+	namespace "http://github.com/Azure/sonic-buffer-queue";
+	prefix bqueue;
+
+	import sonic-extension {
+		prefix sonic-ext;
+	}
+
+	import sonic-port {
+		prefix prt;
+	}
+
+	import sonic-buffer-profile {
+		prefix bpf;
+	}
+
+	organization
+		"SONiC";
+
+	contact
+		"SONiC";
+
+	description
+		"SONIC BUFFER QUEUE";
+
+	revision 2019-05-15 {
+		description
+			"Initial revision.";
+	}
+
+
+	container sonic-buffer-queue {
+
+		container BUFFER_QUEUE {
+
+			list BUFFER_QUEUE_LIST {
+				key "ifname qindex";
+				sonic-ext:key-pattern "QUEUE|{ifname}|{qindex}"; //special pattern used for extracting keys from redis-key and populate the yang instance
+										   // Total list instances = number(key1) * number(key2) * number(key3)
+
+				leaf ifname {
+					type leafref {
+						path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:ifname";
+					}
+				}
+
+				leaf qindex {
+					type string {
+						pattern "[0-7]((-)[0-7])?"{
+							error-message "Invalid Q-index";
+							error-app-tag qindex-invalid;
+						}
+					}
+				}
+
+				leaf profile { //Hash reference key
+					type leafref {
+						path "/bpf:sonic-buffer-profile/bpf:BUFFER_PROFILE/bpf:BUFFER_PROFILE_LIST/bpf:name";
+					}
+				}
+
+			}
+		}
+	}
+}


### PR DESCRIPTION
1) Added Buffer yangs files derived from cvl/testdata/schema. These are used by mgmt-framework.
2) Updated BUFFER_PG|({ifname},)*|{pg_num} to BUFFER_PG|{ifname}|{pg_num} in sonic-buffer-pg.yang.
This change is required configuration migration for dynamic port breakout operation.
3) Added sonic-buffer-queue.yang 