### PR TITLE
Adding pfc yang files

### DIFF
--- a/models/yang/sonic/sonic-pfc-priority-queue-map.yang
+++ b/models/yang/sonic/sonic-pfc-priority-queue-map.yang
@@ -1,0 +1,58 @@
+module sonic-pfc-priority-queue-map {
+	namespace "http://github.com/Azure/sonic-pfc-priority-queue-map";
+	prefix ppq;
+
+	import sonic-extension {
+		prefix sonic-ext;
+	}
+
+	organization
+		"SONiC";
+
+	contact
+		"SONiC";
+
+	description
+		"SONIC MAP_PFC_PRIORITY_TO_QUEUE";
+
+	revision 2019-05-15 {
+		description
+			"Initial revision.";
+	}
+
+	container sonic-pfc-priority-queue-map {	
+
+		container MAP_PFC_PRIORITY_TO_QUEUE {
+
+			list MAP_PFC_PRIORITY_TO_QUEUE_LIST {
+				key "name";
+				sonic-ext:map-list true; //special conversion for map tables
+				sonic-ext:map-leaf "pfc_priority qindex"; //every key:value pair is mapped to list keys, e.g. "1":"7" ==> pfc_priority=1, qindex=7
+
+				leaf name {
+                    type string {
+                        pattern '[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})';
+                        length 1..32;
+                    }
+				}
+
+				list MAP_PFC_PRIORITY_TO_QUEUE { //this is list inside list for storing mapping between two fields
+					key "pfc_priority qindex";
+
+					leaf pfc_priority {
+						type string {
+							pattern "[0-9]?";
+						}
+					}
+
+					leaf qindex {
+						type string {
+							pattern "[0-9]?";
+						}
+					}
+				}
+
+			}
+		}
+	}
+}

--- a/models/yang/sonic/sonic-qos-pfc.yang
+++ b/models/yang/sonic/sonic-qos-pfc.yang
@@ -1,0 +1,135 @@
+module sonic-qos-pfc {
+  namespace "http://github.com/Azure/sonic-qos-pfc";
+  prefix sonic-qos-pfc;
+
+  yang-version 1.1;
+
+  import sonic-extension {
+      prefix sonic-ext;
+  }
+
+  organization
+      "SONiC";
+
+  contact
+      "SONiC";
+
+  description
+      "SONIC QoS Priority-based Flow Control";
+
+  revision 2020-07-16 {
+      description
+          "Initial revision.";
+  }
+
+/*
+ * RPCs
+*/
+    rpc rpc_clear_qos_pfc {
+        description "RPC for clearing interface PFC watchdog counters.";
+
+        input {
+            leaf interface-param {
+                type string;
+                    description
+                        "parameter for clearing counters - all or interface type(Ethernet/PortChannel) or interface name";
+                }
+        }
+        output {
+            leaf status {
+                type int32;
+                description
+                    "The status of the operation execution request.";
+            }
+            leaf status-detail {
+                type string;
+                description
+                    "The detailed status of the operation execution request.";
+            }
+        }
+    }
+
+  container sonic-qos-pfc {
+
+    container FLEX_COUNTER_TABLE {
+      description
+        "Flex Counter Table";
+      list FLEX_COUNTER_TABLE_LIST {
+        description
+          "Flex Counter Table List";
+        key "id";
+
+        leaf id {
+          description
+            "Key for Flex Counter Table";
+          type enumeration {
+            enum PFCWD;
+            enum PORT;
+            enum QUEUE;
+          }
+        }
+
+        leaf FLEX_COUNTER_STATUS {
+          type enumeration {
+            enum enable;
+            enum disable;
+          }
+          description
+            "Indication as to whether PFC Flex Counter is enabled or
+             disabled.";
+        }
+      }
+    }
+
+    container PFC_WD {
+      sonic-ext:db-name "CONFIG_DB";
+      list PFC_WD_LIST {
+        key "ifname";
+
+        leaf ifname {
+            type string {
+                pattern "Ethernet([1-3][0-9]{3}|[1-9][0-9]{2}|[1-9][0-9]|[0-9])|GLOBAL" {
+                    error-message "Invalid interface name";
+                    error-app-tag interface-name-invalid;
+                }
+            }
+        }
+
+        leaf action {
+          type enumeration {
+            enum drop;
+            enum forward;
+            enum  alert;
+          }
+          description
+            "PFC watchdog action when entering storm state.";
+        }
+
+        leaf detection_time {
+          type uint32 {
+            range 100..5000;
+          }
+          description
+            "Detection interval for pause storm.";
+        }
+
+        leaf restoration_time {
+          type uint32 {
+            range 100..60000;
+          }
+          description
+            "Time delay before resuming normal PFC operation.";
+        }
+
+        leaf POLL_INTERVAL {
+          type uint32 {
+            range 100..3000;
+          }
+          description
+            "Priority-based Flow Control global watchdog polling
+             interval.";
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
1.  Adding sonic-pfc-priority-queue-map.yang & sonic-qos-pfc.yang files. These are used by mgmt-framework.
2.  sonic-pfc-priority-queue-map.yang  is required to map PFC priority to a specific queue.
3.  sonic-qos-pfc.yang is required for -
-  clearing interface PFC watchdog counters
-  configuring action,detection_time, restoration time of an an interface for PFC watchdog.