### PR TITLE
[Build]: Support to build in debian bullseye with golang 1.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ stages:
       vmImage: ubuntu-20.04
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster:latest
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye:latest
 
     steps:
     - checkout: self
@@ -50,7 +50,7 @@ stages:
         sudo service redis-server start
 
         # LIBYANG
-        sudo dpkg -i ../target/debs/buster/libyang*1.0.73*.deb
+        sudo dpkg -i ../target/debs/bullseye/libyang*1.0.73*.deb
       displayName: "Install dependency"
 
     - script: |

--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,7 @@ Source: sonic-mgmt-common
 Maintainer: Sachin Holla <sachin.holla@broadcom.com>
 Build-Depends: debhelper (>= 8.0.0),
                dh-systemd
+               | debhelper (>= 9.20160709)
 Vcs-Git: https://github.com/Azure/sonic-mgmt-common
 Homepage: https://github.com/Azure/SONiC/
 Standards-Version: 3.9.3

--- a/translib/db/db.go
+++ b/translib/db/db.go
@@ -631,7 +631,7 @@ func (d *DB) doCVL(ts *TableSpec, cvlOps []cvl.CVLOperation, key Key, vals []Val
 
 		default:
 			glog.Error("doCVL: Unknown, op: ", cvlOps[i])
-			e = errors.New("Unknown Op: " + string(cvlOps[i]))
+			e = errors.New("Unknown Op: " + string(rune(cvlOps[i])))
 		}
 
 	}
@@ -695,7 +695,7 @@ func (d *DB) doWrite(ts *TableSpec, op _txOp, key Key, val interface{}) error {
 		e = errors.New("Cannot issue {Set|Mod|Delete}Entry in txStateMultiExec")
 	default:
 		glog.Error("doWrite: Unknown, txState: ", d.txState)
-		e = errors.New("Unknown State: " + string(d.txState))
+		e = errors.New("Unknown State: " + string(rune(d.txState)))
 	}
 
 	if e != nil {
@@ -739,7 +739,7 @@ func (d *DB) doWrite(ts *TableSpec, op _txOp, key Key, val interface{}) error {
 
 		default:
 			glog.Error("doWrite: Unknown, op: ", op)
-			e = errors.New("Unknown Op: " + string(op))
+			e = errors.New("Unknown Op: " + string(rune(op)))
 		}
 
 		goto doWriteExit
@@ -757,7 +757,7 @@ func (d *DB) doWrite(ts *TableSpec, op _txOp, key Key, val interface{}) error {
 
 	default:
 		glog.Error("doWrite: Unknown, op: ", op)
-		e = errors.New("Unknown Op: " + string(op))
+		e = errors.New("Unknown Op: " + string(rune(op)))
 	}
 
 	if e != nil {
@@ -1340,7 +1340,7 @@ func (d *DB) CommitTx() error {
 		e = errors.New("Cannot issue MULTI in txStateMultiExec")
 	default:
 		glog.Error("CommitTx: Unknown, txState: ", d.txState)
-		e = errors.New("Unknown State: " + string(d.txState))
+		e = errors.New("Unknown State: " + string(rune(d.txState)))
 	}
 
 	if e != nil {
@@ -1410,7 +1410,7 @@ func (d *DB) CommitTx() error {
 
 		default:
 			glog.Error("CommitTx: Unknown, op: ", d.txCmds[i].op)
-			e = errors.New("Unknown Op: " + string(d.txCmds[i].op))
+			e = errors.New("Unknown Op: " + string(rune(d.txCmds[i].op)))
 		}
 
 		if e != nil {
@@ -1484,7 +1484,7 @@ func (d *DB) AbortTx() error {
 		e = errors.New("Cannot issue UNWATCH in txStateMultiExec")
 	default:
 		glog.Error("AbortTx: Unknown, txState: ", d.txState)
-		e = errors.New("Unknown State: " + string(d.txState))
+		e = errors.New("Unknown State: " + string(rune(d.txState)))
 	}
 
 	if e != nil {

--- a/translib/db/db.go
+++ b/translib/db/db.go
@@ -631,7 +631,7 @@ func (d *DB) doCVL(ts *TableSpec, cvlOps []cvl.CVLOperation, key Key, vals []Val
 
 		default:
 			glog.Error("doCVL: Unknown, op: ", cvlOps[i])
-			e = errors.New("Unknown Op: " + string(rune(cvlOps[i])))
+			e = fmt.Errorf("Unknown Op: %d", cvlOps[i])
 		}
 
 	}

--- a/translib/db/db.go
+++ b/translib/db/db.go
@@ -695,7 +695,7 @@ func (d *DB) doWrite(ts *TableSpec, op _txOp, key Key, val interface{}) error {
 		e = errors.New("Cannot issue {Set|Mod|Delete}Entry in txStateMultiExec")
 	default:
 		glog.Error("doWrite: Unknown, txState: ", d.txState)
-		e = errors.New("Unknown State: " + string(rune(d.txState)))
+		e = fmt.Errorf("Unknown State: %d", d.txState)
 	}
 
 	if e != nil {
@@ -739,7 +739,7 @@ func (d *DB) doWrite(ts *TableSpec, op _txOp, key Key, val interface{}) error {
 
 		default:
 			glog.Error("doWrite: Unknown, op: ", op)
-			e = errors.New("Unknown Op: " + string(rune(op)))
+			e = fmt.Errorf("Unknown Op: %d", op)
 		}
 
 		goto doWriteExit
@@ -757,7 +757,7 @@ func (d *DB) doWrite(ts *TableSpec, op _txOp, key Key, val interface{}) error {
 
 	default:
 		glog.Error("doWrite: Unknown, op: ", op)
-		e = errors.New("Unknown Op: " + string(rune(op)))
+		e = fmt.Errorf("Unknown Op: %d", op)
 	}
 
 	if e != nil {
@@ -1340,7 +1340,7 @@ func (d *DB) CommitTx() error {
 		e = errors.New("Cannot issue MULTI in txStateMultiExec")
 	default:
 		glog.Error("CommitTx: Unknown, txState: ", d.txState)
-		e = errors.New("Unknown State: " + string(rune(d.txState)))
+		e = fmt.Errorf("Unknown State: %d", d.txState)
 	}
 
 	if e != nil {
@@ -1410,7 +1410,7 @@ func (d *DB) CommitTx() error {
 
 		default:
 			glog.Error("CommitTx: Unknown, op: ", d.txCmds[i].op)
-			e = errors.New("Unknown Op: " + string(rune(d.txCmds[i].op)))
+			e = fmt.Errorf("Unknown Op: %d", d.txCmds[i].op)
 		}
 
 		if e != nil {
@@ -1484,7 +1484,7 @@ func (d *DB) AbortTx() error {
 		e = errors.New("Cannot issue UNWATCH in txStateMultiExec")
 	default:
 		glog.Error("AbortTx: Unknown, txState: ", d.txState)
-		e = errors.New("Unknown State: " + string(rune(d.txState)))
+		e = fmt.Errorf("Unknown State: %d", d.txState)
 	}
 
 	if e != nil {


### PR DESCRIPTION
Support to build in debian bullseye, the dh-systemd has removed and merged into debhelper.
Support to build by golang 1.15, fix the int type conversion error.

The change does not break the buster build, the first commit is good.